### PR TITLE
Remove French msgstr's which inadvertently got in English PO file

### DIFF
--- a/locale/en/LC_MESSAGES/messages.po
+++ b/locale/en/LC_MESSAGES/messages.po
@@ -250,7 +250,7 @@ msgstr ""
 #: pygeoapi/templates/collections/items/index.html:64
 #: pygeoapi/templates/collections/items/item.html:62
 msgid "Next"
-msgstr "Suivant"
+msgstr ""
 
 #: build/lib/pygeoapi/templates/collections/items/index.html:114
 #: pygeoapi/templates/collections/items/index.html:114
@@ -326,7 +326,7 @@ msgstr ""
 #: build/lib/pygeoapi/templates/processes/process.html:25
 #: pygeoapi/templates/processes/process.html:25
 msgid "Data Type"
-msgstr "Type de données"
+msgstr ""
 
 #: build/lib/pygeoapi/templates/processes/process.html:26
 #: build/lib/pygeoapi/templates/processes/process.html:56


### PR DESCRIPTION
Caught this while checking recent commits and comparing difference from upstream geopython/pygeoapi, but I could be wrong.  Thanks!